### PR TITLE
Add additional kwargs options for sentry setup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "strapp"
-version = "0.2.3"
+version = "0.2.4"
 description = ""
 authors = []
 packages = [

--- a/src/strapp/sentry.py
+++ b/src/strapp/sentry.py
@@ -10,7 +10,7 @@ log = logging.getLogger(__name__)
 
 
 def setup_sentry(
-    dsn, environment=None, service_name=None, level="WARNING", breadcrumb_level="INFO"
+    dsn, environment=None, service_name=None, level="WARNING", breadcrumb_level="INFO", **kwargs,
 ):
     """Initialize sentry.
 
@@ -25,6 +25,7 @@ def setup_sentry(
         attach_stacktrace=True,
         environment=environment,
         server_name=service_name,
+        **kwargs,
     )
 
 


### PR DESCRIPTION
Enable passing of arbitrary `kwargs` to `sentry_sdk.init`, mainly to enable apps to pass the `version` arg if they so desire. 