### PR TITLE
Fix unused flask config param

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "strapp"
-version = "0.2.5"
+version = "0.2.6"
 description = ""
 authors = []
 packages = [

--- a/src/strapp/flask/base.py
+++ b/src/strapp/flask/base.py
@@ -102,7 +102,7 @@ def create_app(
     callbacks = callbacks or []
 
     app = flask.Flask(__name__, **flask_args)
-    app.config.update()
+    app.config.update(**(config or {}))
 
     register_error_handlers(app, error_handlers)
     register_routes(app, routes)

--- a/tests/flask/test_base.py
+++ b/tests/flask/test_base.py
@@ -72,3 +72,9 @@ def test_route_registered():
 
 def test_non_proxied():
     create_app([], proxied=False)
+
+
+def test_config_applied():
+    app = create_app(config={"foo": "bar"})
+
+    assert app.config["foo"] == "bar"


### PR DESCRIPTION
The `config` param to `strapp.flask.base.create_app` was unused. Now the mapping will be applied to the flask app config object.