### PR TITLE
fix: Improve managed_request and HttpClient.request typing.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "strapp"
-version = "0.3.0"
+version = "0.3.1"
 description = ""
 authors = []
 packages = [
@@ -10,7 +10,10 @@ include = ["src/strapp/py.typed"]
 
 [tool.poetry.dependencies]
 python = "^3.6"
-dataclasses = { version = "*", optional = true, python = ">=3.6, <3.7" }
+
+dataclasses = { version = "*", python = ">=3.6, <3.7" }
+typing_extensions = { version = ">=3.10", python = "<=3.10" }
+
 click = { version = "*", optional = true }
 flask = { version = "*", optional = true }
 sentry-sdk = { version = "*", optional = true }

--- a/src/strapp/http/request.py
+++ b/src/strapp/http/request.py
@@ -2,9 +2,14 @@ import abc
 import contextlib
 import socket
 from dataclasses import dataclass, replace
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union, TypeVar
 
 import backoff
+
+try:
+    from typing import ParamSpec
+except ImportError:
+    from typing_extensions import ParamSpec
 
 
 def from_field(mapper, *fields):
@@ -176,6 +181,10 @@ class PreparedRequest(Request):
         return replace(self)
 
 
+P = ParamSpec("P")
+R = TypeVar("R")
+
+
 @contextlib.contextmanager
 def managed_request(retries=6, max_time=60 * 5, base=2, factor=3, exceptions=()):
     """Intercept all outgoing requests so they can be safety-wrapped.
@@ -206,7 +215,7 @@ def managed_request(retries=6, max_time=60 * 5, base=2, factor=3, exceptions=())
         base=base,
         factor=factor,
     )
-    def request_fn(fn, *args, **kwargs):
+    def request_fn(fn: Callable[P, R], *args: P.args, **kwargs: P.kwargs) -> R:
         return fn(*args, **kwargs)
 
     try:


### PR DESCRIPTION
<img width="882" alt="Screen Shot 2022-01-12 at 9 55 10 AM" src="https://user-images.githubusercontent.com/701548/149164100-b659d423-16e7-4ff1-8942-59a4f70f8f9f.png">
vs
<img width="859" alt="Screen Shot 2022-01-12 at 9 30 30 AM" src="https://user-images.githubusercontent.com/701548/149164168-3be00a36-c4d3-435f-820b-606a4470d886.png">

the screenshot only shows marginal benefit, but for LSP features this is much better