### PR TITLE
feat: Apply generics typing to Request/PreparedRequest.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "strapp"
-version = "0.3.2"
+version = "0.3.3"
 description = ""
 authors = []
 packages = [

--- a/src/strapp/datadog.py
+++ b/src/strapp/datadog.py
@@ -5,7 +5,6 @@ import logging
 from typing import Any, Dict, Optional, Union
 
 import datadog
-
 from configly import Config
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
<img width="761" alt="Screen Shot 2022-01-18 at 11 11 07 AM" src="https://user-images.githubusercontent.com/701548/149978043-5b2b883a-f95c-4ce1-862e-3a2990bd16ce.png">

notably the bottom type hint popup. it now realizes that the return value of the request call will be a `Bar` instance