### PR TITLE
fix: removes check for response attribute on the exception in retry.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### [v0.3.10](https://github.com/schireson/strapp/compare/v0.3.9...v0.3.10) (2022-05-03)
+
+#### Fixes
+
+* Fixes a bug in the 'default_give_up_retries' function ecec322
+
 ### [v0.3.9](https://github.com/schireson/strapp/compare/v0.3.8...v0.3.9) (2022-04-27)
 
 #### Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "strapp"
-version = "0.3.9"
+version = "0.3.10"
 description = ""
 authors = []
 packages = [

--- a/src/strapp/http/client.py
+++ b/src/strapp/http/client.py
@@ -30,10 +30,7 @@ class Http5XXError(requests.exceptions.HTTPError):
 
 
 def default_give_up_retries(e):
-    if e.response is None:
-        raise e
-
-    if isinstance(e, requests.exceptions.HTTPError):
+    if isinstance(e, requests.exceptions.HTTPError) and e.response is not None:
         return 400 <= e.response.status_code < 500 and e.response.status_code != 429
     elif (
         isinstance(e, requests.exceptions.ConnectionError)


### PR DESCRIPTION
Previously, the exception raised by an HTTP request needed a response attribute in order to get into the exponential backoff retry loop. This attribute will not be present on ConnectionErrors and things of the like.
