### PR TITLE
fix: Add new exception types to default http backoff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "strapp"
-version = "0.3.14"
+version = "0.3.15"
 description = ""
 authors = []
 packages = [

--- a/src/strapp/http/client.py
+++ b/src/strapp/http/client.py
@@ -89,6 +89,7 @@ class HttpClient:
                 requests.exceptions.HTTPError,
                 requests.exceptions.ConnectionError,
                 requests.exceptions.Timeout,
+                requests.exceptions.ChunkedEncodingError,
             ),
             max_time=210,
             max_tries=retries,


### PR DESCRIPTION
~~ConnectionError and~~ ChunkedEncodingError are common errors we deal with, it seems they should be automatically retried. 